### PR TITLE
Remove use of `pretty` dependency

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -17,15 +17,15 @@ Usage
 
 ```sh
 $ pdf2msgpack --font-info 0-example.pdf | p2m-reader
-2016/07/15 16:40:36 FileName: "0-example.pdf"
-2016/07/15 16:40:36 Pages: 4
-2016/07/15 16:40:36 Creator: "Microsoft® Office Word 2007"
-2016/07/15 16:40:36 Producer: "Microsoft® Office Word 2007"
-p2m.FontInfo{Name:"ABCDEE+Cambria,Bold", Type:"TrueType", Encoding:"WinAnsi", Embedded:true, Subset:true, ToUnicode:false}
-p2m.FontInfo{Name:"ABCDEE+Cambria", Type:"TrueType", Encoding:"WinAnsi", Embedded:true, Subset:true, ToUnicode:false}
-p2m.FontInfo{Name:"ABCDEE+Calibri", Type:"TrueType", Encoding:"WinAnsi", Embedded:true, Subset:true, ToUnicode:false}
-2016/07/15 16:40:36 Page i=1 s={595.4 841.8} len(paths)=4 len(glyphs)=34
-2016/07/15 16:40:36 Page i=2 s={595.4 841.8} len(paths)=238 len(glyphs)=300
-2016/07/15 16:40:36 Page i=3 s={595.4 841.8} len(paths)=237 len(glyphs)=301
-2016/07/15 16:40:36 Page i=4 s={595.4 841.8} len(paths)=237 len(glyphs)=306
+2025/09/15 16:54:06 FileName: "example.pdf"
+2025/09/15 16:54:06 Pages: 4
+2025/09/15 16:54:06 Creator: "Microsoft® Office Word 2007"
+2025/09/15 16:54:06 Producer: "Microsoft® Office Word 2007"
+2025/09/15 16:54:06 FontInfo: {Name:ABCDEE+Cambria,Bold Type:TrueType Encoding:WinAnsi Embedded:true Subset:true ToUnicode:false}
+2025/09/15 16:54:06 FontInfo: {Name:ABCDEE+Cambria Type:TrueType Encoding:WinAnsi Embedded:true Subset:true ToUnicode:false}
+2025/09/15 16:54:06 FontInfo: {Name:ABCDEE+Calibri Type:TrueType Encoding:WinAnsi Embedded:true Subset:true ToUnicode:false}
+2025/09/15 16:54:06 Page i=1 s={595.4 841.8} len(paths)=4 len(glyphs)=34
+2025/09/15 16:54:06 Page i=2 s={595.4 841.8} len(paths)=238 len(glyphs)=300
+2025/09/15 16:54:06 Page i=3 s={595.4 841.8} len(paths)=237 len(glyphs)=301
+2025/09/15 16:54:06 Page i=4 s={595.4 841.8} len(paths)=237 len(glyphs)=306
 ```

--- a/go/cmd/p2m-reader/main.go
+++ b/go/cmd/p2m-reader/main.go
@@ -5,8 +5,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/kr/pretty"
-
 	"github.com/sensiblecodeio/pdf2msgpack/go/pkg/p2m"
 )
 
@@ -23,7 +21,7 @@ func main() {
 
 	if r.Meta.FontInfo != nil {
 		for _, fi := range *r.Meta.FontInfo {
-			pretty.Println(fi)
+			log.Printf("FontInfo: %+v\n", fi)
 		}
 	}
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -2,12 +2,6 @@ module github.com/sensiblecodeio/pdf2msgpack/go
 
 go 1.19
 
-require (
-	github.com/kr/pretty v0.2.1
-	github.com/tinylib/msgp v1.1.2
-)
+require github.com/tinylib/msgp v1.1.2
 
-require (
-	github.com/kr/text v0.1.0 // indirect
-	github.com/philhofer/fwd v1.0.0 // indirect
-)
+require github.com/philhofer/fwd v1.0.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,8 +1,3 @@
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/philhofer/fwd v1.0.0 h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=


### PR DESCRIPTION
It wasn't adding much to the formatting here, so let's remove it.

We do lose the commas between struct fields, but that's fine.